### PR TITLE
Patch-based Data

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -16,6 +16,7 @@ There are several types of models that can be trained:
   - base (*full sinograms for input & output*)
   - mask (*masked sinograms for input & output*)
   - simple (*same as mask, but masks are calculated in a simpler way*)
+  - patch (*same as simple, but works on patches of sinograms*)
   - window & full (*uses windowed sinograms, left over from an old method & not used anymore*)
 
 More details about each mode can be found below.<br>
@@ -168,6 +169,12 @@ mask[mask > 0] = 1
 mask = mask.astype(np.bool_)
 ```
 The Generator class for Simple models is `BaseUNet`, and the Discriminator class is `BaseDiscriminator`.<br>
+The GAN class is `MaskedGAN`.<br>
+
+### Patch
+Patch models are identical to Simple models, but rather than working on full sinograms, the model is applied to patches.<br>
+Patches must be of size `(1801, 256)` and generated according to [Patch](../simulator/README.md#Patch) mode in data generation.<br>
+The Generator class for Path models is `PatchUNet`, and the Discriminator class is `PatchDiscriminator`<br>
 The GAN class is `MaskedGAN`.<br>
 
 ### Window and Full

--- a/network/datasets.py
+++ b/network/datasets.py
@@ -442,12 +442,6 @@ class MaskedDataset(BaseDataset):
         diff = np.abs(clean - stripe)
         mask[diff > diff.min()] = 1
 
-        # expand mask widths by one pixel
-        zero_prepend = [0 for _ in range(mask.ndim - 1)]
-        stripe_idxs = np.where(mask[zero_prepend, :] == 1)[0]
-        for stripe_idx in stripe_idxs:
-            mask[..., stripe_idx-1:stripe_idx+1] = 1
-
         if isinstance(clean, torch.Tensor):
             mask = torch.tensor(mask)
         return mask

--- a/network/datasets.py
+++ b/network/datasets.py
@@ -73,6 +73,8 @@ class BaseDataset(Dataset):
         self.tvt = tvt
         # Create list of all target/input image pairs
         self.all_filepaths = getPairedFilepaths(root)
+        rng = np.random.default_rng()
+        rng.shuffle(self.all_filepaths)
         # Set current dataset to the dataset that corresponds to mode
         self.mode, self.datasets, self.filepaths = None, [], []
         self.setMode(mode)

--- a/network/datasets.py
+++ b/network/datasets.py
@@ -26,6 +26,8 @@ def getPairedFilepaths(root):
     input_filepaths = []
     for root, sub_dirs, images in os.walk(root):
         sub_dirs[:] = sorted(sub_dirs)
+        if 'real_artifacts' in root:
+            sub_dirs[:] = []
         if 'clean' in sub_dirs:
             clean_path = Path(root) / 'clean'
             clean_images = sorted(os.listdir(clean_path))

--- a/network/models/discriminators.py
+++ b/network/models/discriminators.py
@@ -70,6 +70,33 @@ class BaseDiscriminator(nn.Module):
         )
 
 
+class PatchDiscriminator(nn.Module):
+    """Discriminator that runs on patches of size (1801, 256).
+    For use when mode == 'patch'.
+    Has a similar structure to BaseDiscriminator, but with (1, 1) padding in
+    every layer.
+    """
+    def __init__(self):
+        super(PatchDiscriminator, self).__init__()
+        filters = 64
+        self.down = BaseDiscriminator.down
+
+        self.model = nn.Sequential(
+            self.down(2, filters, batchNorm=False),
+            self.down(filters, filters*2, p=(1, 1)),
+            self.down(filters*2, filters*4, p=(1, 1)),
+            self.down(filters*4, filters*8, p=(1, 1)),
+            self.down(filters*8, filters*8, p=(1, 1)),
+            self.down(filters*8, filters*8, p=(1, 1)),
+            self.down(filters*8, filters*8, p=(1, 1)),
+            nn.Conv2d(filters*8, 1, kernel_size=(4, 4), stride=(2, 2),
+                      padding=(1, 1), bias=False)
+        )
+
+    def forward(self, x):
+        return self.model(x)
+
+
 class WindowDiscriminator(nn.Module):
     """Discriminator used by GANs training on windowed sinograms.
     Assumes window width = 25, and cannot scale to different widths.

--- a/network/models/discriminators.py
+++ b/network/models/discriminators.py
@@ -82,7 +82,7 @@ class PatchDiscriminator(nn.Module):
         self.down = BaseDiscriminator.down
 
         self.model = nn.Sequential(
-            self.down(2, filters, batchNorm=False),
+            self.down(2, filters, p=(1, 1), batchNorm=False),
             self.down(filters, filters*2, p=(1, 1)),
             self.down(filters*2, filters*4, p=(1, 1)),
             self.down(filters*4, filters*8, p=(1, 1)),

--- a/network/models/discriminators.py
+++ b/network/models/discriminators.py
@@ -49,7 +49,7 @@ class BaseDiscriminator(nn.Module):
             # Input (512, 4, 4) -> Output (1, 1, 1)
             nn.Conv2d(filters*8, 1,
                       kernel_size=(4, 4), stride=(2, 2),
-                      padding=(0, 0), bias=False),
+                      padding=(0, 0), bias=True),
         )
 
     def forward(self, x):
@@ -64,7 +64,7 @@ class BaseDiscriminator(nn.Module):
             batchNorm = nn.Identity()
         return nn.Sequential(
             nn.Conv2d(in_c, out_c, kernel_size=k, stride=s, padding=p,
-                      bias=False),
+                      bias=True),
             batchNorm,
             nn.LeakyReLU(0.2, inplace=True)
         )
@@ -90,7 +90,7 @@ class PatchDiscriminator(nn.Module):
             self.down(filters*8, filters*8, p=(1, 1)),
             self.down(filters*8, filters*8, p=(1, 1)),
             nn.Conv2d(filters*8, 1, kernel_size=(4, 4), stride=(2, 2),
-                      padding=(1, 1), bias=False)
+                      padding=(1, 1), bias=True)
         )
 
     def forward(self, x):

--- a/network/models/gans.py
+++ b/network/models/gans.py
@@ -69,7 +69,7 @@ class BaseGAN:
         else:
             self.device = device
         self.gen = gen.to(self.device)
-        self.disc = disc.to(self.device)
+        self.disc = disc
         self.lsgan = lsgan
         self.setMode(mode)
         self.lossD_values = []
@@ -77,6 +77,7 @@ class BaseGAN:
 
         # if training, set up loss, optimizer & scheduler functions
         if self.mode == 'train':
+            self.disc.to(self.device)
             if self.lsgan:
                 self.lossGAN = nn.MSELoss().to(self.device)
             else:

--- a/network/models/gans.py
+++ b/network/models/gans.py
@@ -70,6 +70,8 @@ class BaseGAN:
             self.device = device
         self.gen = gen.to(self.device)
         self.disc = disc
+        if self.disc is not None:
+            self.disc.to(self.device)
         self.lsgan = lsgan
         self.setMode(mode)
         self.lossD_values = []

--- a/network/models/generators.py
+++ b/network/models/generators.py
@@ -158,6 +158,149 @@ class BaseUNet(nn.Module):
         return final_out
 
 
+class PatchUNet(nn.Module):
+    """UNet to generate sinogram patches of size (1801, 256).
+    It consists of an 8-layer decoder and 8-layer encoder, with skip
+    connections inbetween the layers.
+    It has a similar structure to BaseUNet, but with padding=(1, 1) for every
+    layer.
+    """
+    def __init__(self):
+        super(PatchUNet, self).__init__()
+        filters = 64
+
+        # Input (1, 1801, 256) -> Output (64, 900, 128)
+        self.down1 = self.down(1, filters, batchNorm=False)
+
+        # Input (64, 900, 128) -> Output (128, 450, 64)
+        self.down2 = self.down(filters, filters*2)
+
+        # Input (128, 450, 64) -> Output (256, 225, 32)
+        self.down3 = self.down(filters*2, filters*4)
+
+        # Input (256, 225, 32) -> Output (512, 112, 16)
+        self.down4 = self.down(filters*4, filters*8)
+
+        # Input (512, 112, 16) -> Output (512, 56, 8)
+        self.down5 = self.down(filters*8, filters*8)
+
+        # Input (512, 56, 8) -> Output (512, 28, 4)
+        self.down6 = self.down(filters*8, filters*8)
+
+        # Input (512, 28, 4) -> Output (512, 14, 2)
+        self.down7 = self.down(filters*8, filters*8)
+
+        # Input (512, 14, 2) -> Output (512, 7, 1)
+        self.down8 = nn.Sequential(
+            nn.Conv2d(filters*8, filters*8, kernel_size=(4, 4), stride=(2, 2),
+                      padding=(1, 1), bias=False),
+            nn.ReLU(inplace=True)
+        )
+
+        ####### UP #######
+
+        # Input (512, 7, 1) -> Output (512, 14, 2)
+        self.up1 = self.up(filters*8, filters*8, dropout=True)
+
+        # Input (1024, 14, 2) -> Output (512, 28, 4)
+        self.up2 = self.up(filters*8 * 2, filters*8, dropout=True)
+
+        # Input (1024, 28, 4) -> Output (512, 56, 8)
+        self.up3 = self.up(filters*8 * 2, filters*8, dropout=True)
+
+        # Input (1024, 56, 8) -> Output (512, 112, 16)
+        self.up4 = self.up(filters*8 * 2, filters*8)
+
+        # Input (1024, 112, 16) -> Output (256, 225, 32)
+        self.up5 = self.up(filters*8 * 2, filters*4, k=(5, 4))
+
+        # Input (512, 225, 32) -> Output (128, 450, 64)
+        self.up6 = self.up(filters*4 * 2, filters*2)
+
+        # Input (256, 450, 64) -> Output (64, 900, 128)
+        self.up7 = self.up(filters*2 * 2, filters)
+
+        # Input (128, 900, 128) -> Output (1, 1801, 256)
+        self.up8 = nn.Sequential(
+            nn.ConvTranspose2d(filters * 2, 1, (5, 4), (2, 2), (1, 1)),
+            nn.Tanh()
+        )
+
+    def forward(self, x):
+        # Encoder
+        down1_out = self.down1(x)
+        down2_out = self.down2(down1_out)
+        down3_out = self.down3(down2_out)
+        down4_out = self.down4(down3_out)
+        down5_out = self.down5(down4_out)
+        down6_out = self.down6(down5_out)
+        down7_out = self.down7(down6_out)
+        down8_out = self.down8(down7_out)
+
+        # Decoder
+        up1_out = self.up1(down8_out)
+
+        # Skip connections are concatenated
+        up2_in = torch.cat((up1_out, down7_out), dim=1)
+        up2_out = self.up2(up2_in)
+
+        up3_in = torch.cat((up2_out, down6_out), dim=1)
+        up3_out = self.up3(up3_in)
+
+        up4_in = torch.cat((up3_out, down5_out), dim=1)
+        up4_out = self.up4(up4_in)
+
+        up5_in = torch.cat((up4_out, down4_out), dim=1)
+        up5_out = self.up5(up5_in)
+
+        up6_in = torch.cat((up5_out, down3_out), dim=1)
+        up6_out = self.up6(up6_in)
+
+        up7_in = torch.cat((up6_out, down2_out), dim=1)
+        up7_out = self.up7(up7_in)
+
+        up8_in = torch.cat((up7_out, down1_out), dim=1)
+        up8_out = self.up8(up8_in)
+
+        return up8_out
+
+    @staticmethod
+    def down(in_c, out_c, batchNorm=True, k=(4, 4), s=(2, 2), p=(1, 1)):
+        if batchNorm:
+            batchNorm = nn.BatchNorm2d(out_c, eps=0.001,
+                                       track_running_stats=False)
+        else:
+            batchNorm = nn.Identity()
+        return nn.Sequential(
+            nn.Conv2d(in_c, out_c,
+                      kernel_size=k, stride=s,
+                      padding=p, bias=False),
+            batchNorm,
+            nn.LeakyReLU(0.2, inplace=True)
+        )
+
+    @staticmethod
+    def up(in_c, out_c, batchNorm=True, dropout=False, k=(4, 4), s=(2, 2),
+           p=(1, 1)):
+        if batchNorm:
+            batchNorm = nn.BatchNorm2d(out_c, eps=0.001,
+                                       track_running_stats=False)
+        else:
+            batchNorm = nn.Identity()
+        if dropout:
+            dropout = nn.Dropout(0.5)
+        else:
+            dropout = nn.Identity()
+        return nn.Sequential(
+            nn.ConvTranspose2d(in_c, out_c,
+                               kernel_size=k, stride=s,
+                               padding=p, bias=False),
+            batchNorm,
+            dropout,
+            nn.ReLU(inplace=True),
+        )
+
+
 class WindowUNet(nn.Module):
     """Generator used by GANs training on windowed sinograms.
     Assumes window width = 25, and cannot scale to different widths.

--- a/network/models/generators.py
+++ b/network/models/generators.py
@@ -39,7 +39,7 @@ class BaseUNet(nn.Module):
         # Input (1, 402, 362) -> Output (64, 200, 180)
         self.down1 = nn.Conv2d(1, filters,
                                kernel_size=(4, 4), stride=(2, 2),
-                               padding=(0, 0), bias=False)
+                               padding=(0, 0), bias=True)
 
         # Input (64, 200, 180) -> Output (128, 99, 89)
         self.down2 = self.down(filters, filters * 2)
@@ -97,7 +97,7 @@ class BaseUNet(nn.Module):
             nn.LeakyReLU(0.2, inplace=True),
             nn.Conv2d(in_c, out_c,
                       kernel_size=k, stride=s,
-                      padding=p, bias=False),
+                      padding=p, bias=True),
             batchNorm
         )
 
@@ -117,7 +117,7 @@ class BaseUNet(nn.Module):
             nn.ReLU(inplace=True),
             nn.ConvTranspose2d(in_c, out_c,
                                kernel_size=k, stride=s,
-                               padding=p, bias=False),
+                               padding=p, bias=True),
             batchNorm,
             dropout
         )
@@ -193,7 +193,7 @@ class PatchUNet(nn.Module):
         # Input (512, 14, 2) -> Output (512, 7, 1)
         self.down8 = nn.Sequential(
             nn.Conv2d(filters*8, filters*8, kernel_size=(4, 4), stride=(2, 2),
-                      padding=(1, 1), bias=False),
+                      padding=(1, 1), bias=True),
             nn.ReLU(inplace=True)
         )
 
@@ -274,7 +274,7 @@ class PatchUNet(nn.Module):
         return nn.Sequential(
             nn.Conv2d(in_c, out_c,
                       kernel_size=k, stride=s,
-                      padding=p, bias=False),
+                      padding=p, bias=True),
             batchNorm,
             nn.LeakyReLU(0.2, inplace=True)
         )
@@ -294,7 +294,7 @@ class PatchUNet(nn.Module):
         return nn.Sequential(
             nn.ConvTranspose2d(in_c, out_c,
                                kernel_size=k, stride=s,
-                               padding=p, bias=False),
+                               padding=p, bias=True),
             batchNorm,
             dropout,
             nn.ReLU(inplace=True),

--- a/network/patch_visualizer.py
+++ b/network/patch_visualizer.py
@@ -1,0 +1,408 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import os
+import torch
+from utils.data_io import loadTiff, rescale
+from utils.tomography import reconstruct
+from utils.misc import toTensor, toNumpy
+from .visualizers import BaseGANVisualizer
+
+
+class PatchVisualizer:
+    """Class to visualize patches of a sinogram"""
+    def __init__(self, root, model, full_sino_size=(1801, 2560),
+                 patch_size=(1801, 256), block=True, sample_no=0, shift_no=0):
+        """Parameters:
+            root : str
+                Path to root of dataset
+            model : torch.nn.Module
+                The model to process results from.
+            full_sino_size : Tuple[int, int]
+                Size of full sinograms; i.e. once patches have been combined.
+                Default is (1801, 2560).
+            patch_size : Tuple[int, int]
+                Size of patches. Default is (1801, 256).
+            block : bool
+                Whether or not plots should pause execution of code.
+                Default is True.
+            sample_no : int
+                Sample number to load patches from. Default is 0.
+            shift_no : int
+                Shift number to load patches from. Default is 0.
+        """
+        self.root = os.path.dirname(os.path.dirname(root))  # hacky fix
+        self.model = model
+        self.size = full_sino_size
+        self.patch_size = patch_size
+        self.num_patches_h = self.size[0] // self.patch_size[0]
+        self.num_patches_w = self.size[1] // self.patch_size[1]
+        self.num_patches = self.num_patches_h * self.num_patches_w
+        self.block = block
+        self.prefix = f'{sample_no:04}_shift{shift_no:02}'
+        if torch.cuda.is_available():
+            self.device = torch.device('cuda')
+        else:
+            self.device = torch.device('cpu')
+
+    def get_patch(self, index, patch_no, mode):
+        """Get a single patch of a sinogram. If the patch_no given does not
+        exist, an array of all zeroes will be returned.
+        Parameters:
+            index : int
+                Index of the sinogram to retrieve the patch from.
+            patch_no : int
+                Number of the patch to get from the given sinogram.
+            mode : str
+                Mode in which to retrieve patches.
+                Must be one of 'clean', 'stripe', or 'raw'.
+        Returns:
+            np.ndarray
+                The patch. 2D array with shape `self.patch_size`.
+        """
+        if mode == 'raw':
+            sub_dir = 'clean'
+        else:
+            sub_dir = mode
+        path = os.path.join(self.root, 'fake_artifacts', sub_dir,
+                            f'{self.prefix}_{index:04}_w{patch_no:02}')
+        if os.path.exists(path+'.tif'):
+            return loadTiff(path, normalise=False)
+        else:
+            if mode == 'raw':
+                path = os.path.join(self.root, 'real_artifacts', 'stripe',
+                                    f'{self.prefix}_{index:04}_w{patch_no:02}')
+                return loadTiff(path, normalise=False)
+            else:
+                return np.zeros(self.patch_size, dtype=np.uint16)
+
+    def get_model_patch(self, index, patch_no, artifact_type):
+        """Get the output of a model on a given patch.
+        Parameters:
+            index : int
+                Index of the sinogram to retrieve the patch from.
+            patch_no : int
+                Number of the patch to get from the given sinogram.
+            artifact_type : str
+                Indicates the type of data the model should be ran on.
+                'fake' = use fake artifacts and get mask from the absolute
+                         difference between 'clean' and 'stripe'
+                'real' = use real artifacts and get mask from stripe detection
+                         algorithm. Assumes mask has already been saved to disk
+        Returns:
+              np.ndarray
+                The model output on the given patch.
+        """
+        if artifact_type == 'fake':
+            clean = self.get_patch(index, patch_no, 'clean')
+            stripe = self.get_patch(index, patch_no, 'stripe')
+            mask = np.abs(clean - stripe).astype(np.bool_, copy=False)
+        elif artifact_type == 'real':
+            stripe = self.get_patch(index, patch_no, 'raw')
+            mask_file = os.path.join(self.root, 'real_artifacts', 'masks',
+                                     f'mask_{index:04}_w{patch_no:02}.npy')
+            if os.path.exists(mask_file):
+                mask = np.load(mask_file)
+            else:
+                # If no mask exists for this patch, then it doesn't contain a
+                # stripe, so can be immediately returned as is.
+                return stripe
+        else:
+            raise ValueError(f"Mode must be one of ['fake', 'real']. "
+                             f"Instead got '{artifact_type}'.")
+        mask = toTensor(mask, device=self.device).unsqueeze(0).type(torch.bool)
+        stripe = toTensor(rescale(stripe, a=-1, b=1, imin=0, imax=65535),
+                          device=self.device).unsqueeze(0)
+        stripe[mask] = 0
+        model_out = self.model.gen(stripe)
+        model_patch = stripe + mask * model_out
+        return rescale(toNumpy(model_patch), a=0, b=65535, imin=-1,
+                       imax=1).astype(np.uint16, copy=False)
+
+    def get_sinogram(self, index, mode):
+        """Get a full sinogram by combining its patches. If no patch is found
+        for a part of the sinogram, that part will be set to 0.
+        Parameters:
+            index : int
+                Index of the sinogram to return.
+            mode : str
+                Mode in which to retrieve patches.
+                Must be one of 'clean', 'stripe', or 'raw'.
+        Returns:
+            np.ndarray
+                The full sinogram.
+        """
+        full_sino = np.empty(self.size, dtype=np.uint16)
+        for p in range(self.num_patches):
+            current_idx = np.s_[
+                          (p % self.num_patches_h) * self.patch_size[0]:
+                          (p % self.num_patches_h + 1) * self.patch_size[0],
+                          (p // self.num_patches_h) * self.patch_size[1]:
+                          (p // self.num_patches_h + 1) * self.patch_size[1]]
+            full_sino[current_idx] = self.get_patch(index, p, mode)
+        return full_sino
+
+    def get_reconstruction(self, index, mode):
+        """Get a reconstruction of a full sinogram by combining its patches.
+        If no patch is found for a part of the sinogram, that part will be set
+        to 0 (this will cause errors in the reconstruction).
+        Parameters:
+            index : int
+                Index of the sinogram to return.
+            mode : str
+                Mode in which to retrieve patches.
+                Must be one of 'clean', 'stripe', or 'raw'.
+        Returns:
+            np.ndarray
+                The reconstruction of the full sinogram.
+        """
+        sino = self.get_sinogram(index, mode)
+        recon = reconstruct(rescale(sino))
+        return recon
+
+    def get_model_sinogram(self, index, artifact_type):
+        """Get model output of a full sinogram by combining its patches.
+        Parameters:
+            index : int
+                Index of the sinogram to run the model on.
+            artifact_type : str
+                Indicates the type of data the model should be ran on.
+                'fake' = use fake artifacts and get mask from the absolute
+                         difference between 'clean' and 'stripe'
+                'real' = use real artifacts and get mask from stripe detection
+                         algorithm. Assumes mask has already been saved to disk
+        Returns:
+            np.ndarray
+                The output of the model on a full sinogram. Has type np.uint16.
+        """
+        full_sino = np.empty(self.size, dtype=np.uint16)
+        for p in range(self.num_patches):
+            current_idx = np.s_[
+                          (p % self.num_patches_h) * self.patch_size[0]:
+                          (p % self.num_patches_h + 1) * self.patch_size[0],
+                          (p // self.num_patches_h) * self.patch_size[1]:
+                          (p // self.num_patches_h + 1) * self.patch_size[1]]
+            model_patch = self.get_model_patch(index, p, artifact_type)
+            full_sino[current_idx] = model_patch
+        return full_sino
+
+    def get_model_reconstruction(self, index, artifact_type):
+        """Get a reconstruction of model output of a full sinogram.
+        Parameters:
+            index : int
+                Index of the sinogram to run the model on.
+            artifact_type : str
+                Indicates the type of data the model should be ran on.
+                'fake' = use fake artifacts and get mask from the absolute
+                         difference between 'clean' and 'stripe'
+                'real' = use real artifacts and get mask from stripe detection
+                         algorithm. Assumes mask has already been saved to disk
+        Returns:
+            np.ndarray
+                The reconstruction of the output of the model on a full
+                sinogram.
+        """
+        sino = self.get_model_sinogram(index, artifact_type)
+        recon = reconstruct(rescale(sino))
+        return recon
+
+    def plot_sinogram(self, index, mode, show=True):
+        """Plot a sinogram of a given mode.
+        Parameters:
+            index : int
+                Index of the sinogram to plot.
+            mode : str
+                The type of sinogram to plot. Must be one of:
+                'clean' ---------- sinogram with no artifacts and maybe missing
+                                   patches
+                'stripe' --------- sinogram with synthetic artifacts and maybe
+                                   missing patches
+                'real_artifacts' - sinogram with real artifacts and no missing
+                                   patches
+            show : bool
+                Whether the plot should be displayed on screen. Default is True
+        Returns:
+             np.ndarray
+                The clean sinogram.
+        """
+        sino = self.get_sinogram(index, mode)
+        plt.imshow(sino, cmap='gray', vmin=0, vmax=65535)
+        plt.title(f"{mode.capitalize()} {index}")
+        if show:
+            plt.show(block=self.block)
+        return sino
+
+    def plot_reconstruction(self, index, mode, show=True):
+        """Plot a reconstruction of a sinogram.
+        Parameters:
+            index : int
+                Index of the sinogram to reconstruct.
+            mode : str
+                The type of sinogram to reconstruct. Must be one of:
+                'clean' ---------- sinogram with no artifacts and maybe missing
+                                   patches
+                'stripe' --------- sinogram with synthetic artifacts and maybe
+                                   missing patches
+                'real_artifacts' - sinogram with real artifacts and no missing
+                                   patches
+            show : bool
+                Whether the plot should be displayed on screen. Default is True
+        """
+        recon = self.get_reconstruction(index, mode)
+        plt.imshow(recon, cmap='gray', vmin=-0.1, vmax=0.2)
+        plt.title(f"{mode.capitalize()} Reconstruction {index}")
+        if show:
+            plt.show(block=self.block)
+
+    def plot_model_sinogram(self, index, artifact_type, show=True):
+        """Plot the output of the model on a sinogram.
+        Parameters:
+            index : int
+                Index of the sinogram to run the model on.
+            artifact_type : str
+                Indicates the type of artifacts the model should be ran on.
+                'fake' = use fake artifacts and get mask from the absolute
+                         difference between 'clean' and 'stripe'
+                'real' = use real artifacts and get mask from stripe detection
+                         algorithm. Assumes mask has already been saved to disk
+            show : bool
+                Whether the plot should be displayed on screen. Default is True
+        Returns:
+             np.ndarray
+                The output of the model on the given sinogram.
+        """
+        model_sino = self.get_model_sinogram(index, artifact_type)
+        plt.imshow(model_sino, cmap='gray', vmin=0, vmax=65535)
+        plt.title(f"Model Output {index}")
+        if show:
+            plt.show(block=self.block)
+        return model_sino
+
+    def plot_model_reconstruction(self, index, artifact_type, show=True):
+        """Plot reconstruction of the output of the model on a sinogram.
+        Parameters:
+            index : int
+                Index of the sinogram to run the model on.
+            artifact_type : str
+                Indicates the type of artifacts the model should be ran on.
+                'fake' = use fake artifacts and get mask from the absolute
+                         difference between 'clean' and 'stripe'
+                'real' = use real artifacts and get mask from stripe detection
+                         algorithm. Assumes mask has already been saved to disk
+            show : bool
+                Whether the plot should be displayed on screen. Default is True
+        """
+        recon = self.get_model_reconstruction(index, artifact_type)
+        plt.imshow(recon, cmap='gray', vmin=-0.1, vmax=0.2)
+        plt.title(f"Model Output Reconstruction {index}")
+        if show:
+            plt.show(block=self.block)
+
+    def plot_pair(self, index, recon=False):
+        """Plot a pair of clean & stripe sinograms.
+        Parameters:
+            index : int
+                Index of the sinograms to plot.
+            recon : bool
+                Whether the sinograms should be reconstructed as well.
+        Returns:
+             Tuple[np.ndarray, np.ndarray]
+                The clean & stripe sinograms.
+        """
+        if recon:
+            subplot_size = (2, 2)
+        else:
+            subplot_size = (1, 2)
+        plt.subplot(*subplot_size, 1)
+        clean = self.plot_sinogram(index, 'clean', show=False)
+        plt.subplot(*subplot_size, 2)
+        stripe = self.plot_sinogram(index, 'stripe', show=False)
+        if recon:
+            plt.subplot(*subplot_size, 3)
+            self.plot_reconstruction(index, 'clean', show=False)
+            plt.subplot(*subplot_size, 4)
+            self.plot_reconstruction(index, 'stripe', show=False)
+        plt.show(block=self.block)
+        return clean, stripe
+
+    def plot_all(self, index, recon=True):
+        """Plot the images from every stage of the process:
+            Clean, Stripe, Model Output & each of their reconstructions.
+        Parameters:
+            index : int
+                The index of the sinogram to plot.
+            recon : bool
+                Whether reconstructions should be plotted below sinograms.
+        """
+        if recon:
+            subplot_size = (2, 3)
+        else:
+            subplot_size = (1, 3)
+        plt.subplot(*subplot_size, 1)
+        self.plot_sinogram(index, 'clean', show=False)
+        plt.subplot(*subplot_size, 2)
+        self.plot_sinogram(index, 'stripe', show=False)
+        plt.subplot(*subplot_size, 3)
+        self.plot_model_sinogram(index, 'fake', show=False)
+        if recon:
+            plt.subplot(*subplot_size, 4)
+            self.plot_reconstruction(index, 'clean', show=False)
+            plt.subplot(*subplot_size, 5)
+            self.plot_reconstruction(index, 'stripe', show=False)
+            plt.clim(-0.01, 0.03)
+            plt.subplot(*subplot_size, 6)
+            self.plot_model_reconstruction(index, 'fake', show=False)
+            plt.clim(-0.1, 0.15)
+        plt.show(block=self.block)
+
+    def plot_all_raw(self, index, recon=True):
+        """Plot a raw sinogram and the output of the model on this sinogram,
+        as well as their respective reconstructions.
+        Parameters:
+            index : int
+                The index of the sinogram to plot.
+            recon : bool
+                Whether reconstructions should be plotted below sinograms.
+        """
+        if recon:
+            subplot_size = (2, 2)
+        else:
+            subplot_size = (1, 2)
+        plt.subplot(*subplot_size, 1)
+        self.plot_sinogram(index, 'raw', show=False)
+        plt.subplot(*subplot_size, 2)
+        self.plot_model_sinogram(index, 'real', show=False)
+        if recon:
+            plt.subplot(*subplot_size, 3)
+            self.plot_reconstruction(index, 'raw', show=False)
+            plt.subplot(*subplot_size, 4)
+            self.plot_model_reconstruction(index, 'real', show=False)
+        plt.show(block=self.block)
+
+    def plot_losses(self):
+        return BaseGANVisualizer.plot_losses(self)
+
+    def plot_one(self):
+        """Choose a random sinogram index and call `plot_all()`.
+        The name is not accurate to its function; it's only called `plot_one`
+         to keep consistency with the other visualizer APIs.
+        """
+        sino_idx = np.random.randint(0, 2160)
+        self.plot_all(sino_idx, recon=True)
+
+    def plot_real_vs_fake_batch(self):
+        """Choose a random sinogram index and call `plot_all_raw()`.
+        The name is not accurate to its function; it's only called
+        `plot_real_vs_fake_batch` to keep consistency with the other visualizer
+        APIs.
+        """
+        sino_idx = np.random.randint(0, 2160)
+        self.plot_all_raw(sino_idx, recon=True)
+
+    def plot_real_vs_fake_recon(self):
+        """Choose a random sinogram index and call `plot_all_raw()`.
+        The name is not accurate to its function; it's only called
+        `plot_real_vs_fake_recon` to keep consistency with the other visualizer
+        APIs.
+        """
+        sino_idx = np.random.randint(0, 2160)
+        self.plot_all_raw(sino_idx, recon=True)

--- a/network/patch_visualizer.py
+++ b/network/patch_visualizer.py
@@ -233,7 +233,7 @@ class PatchVisualizer:
                                    patches
                 'stripe' --------- sinogram with synthetic artifacts and maybe
                                    missing patches
-                'real_artifacts' - sinogram with real artifacts and no missing
+                'raw' ------------ sinogram with real artifacts and no missing
                                    patches
             show : bool
                 Whether the plot should be displayed on screen. Default is True
@@ -259,7 +259,7 @@ class PatchVisualizer:
                                    patches
                 'stripe' --------- sinogram with synthetic artifacts and maybe
                                    missing patches
-                'real_artifacts' - sinogram with real artifacts and no missing
+                'raw' ------------ sinogram with real artifacts and no missing
                                    patches
             show : bool
                 Whether the plot should be displayed on screen. Default is True
@@ -354,6 +354,7 @@ class PatchVisualizer:
             subplot_size = (2, 3)
         else:
             subplot_size = (1, 3)
+        plt.suptitle('Synthetic Stripes', size='xx-large')
         plt.subplot(*subplot_size, 1)
         self.plot_sinogram(index, 'clean', show=False)
         plt.subplot(*subplot_size, 2)
@@ -384,6 +385,7 @@ class PatchVisualizer:
             subplot_size = (2, 2)
         else:
             subplot_size = (1, 2)
+        plt.suptitle('Real-life Stripes', size='xx-large')
         plt.subplot(*subplot_size, 1)
         self.plot_sinogram(index, 'raw', show=False)
         plt.subplot(*subplot_size, 2)

--- a/network/patch_visualizer.py
+++ b/network/patch_visualizer.py
@@ -30,7 +30,7 @@ class PatchVisualizer:
             shift_no : int
                 Shift number to load patches from. Default is 0.
         """
-        self.root = os.path.dirname(os.path.dirname(root))  # hacky fix
+        self.root = os.path.dirname(root)  # hacky fix
         self.model = model
         self.size = full_sino_size
         self.patch_size = patch_size

--- a/network/testing.py
+++ b/network/testing.py
@@ -162,8 +162,8 @@ def get_args():
     parser.add_argument('-r', "--root", type=str, default='./data',
                         help="Path to input data used in network.")
     parser.add_argument('-m', "--model", type=str, default='base',
-                        help="Type of model to test. Must be one of "
-                             "['base', 'mask', 'simple', 'window', 'full'].")
+                        help="Type of model to train. Must be one of ['base', "
+                             "'mask', 'simple', 'patch', 'window', 'full'].")
     parser.add_argument('-N', "--size", type=int, default=256,
                         help="Number of sinograms per sample.")
     parser.add_argument('-s', "--shifts", type=int, default=5,
@@ -259,10 +259,17 @@ if __name__ == '__main__':
                                 transform=transform,
                                 simple=model_name=='simple')
         model = MaskedGAN(gen, disc, mode='test', device=device)
+    elif args.model == 'patch':
+        dataset = MaskedDataset(root=dataroot, mode='test', tvt=tvt,
+                                size=size, shifts=num_shifts,
+                                transform=transform, simple=True)
+        disc = PatchDiscriminator()
+        gen = PatchUNet()
+        model = MaskedGAN(gen, disc, mode='test', device=device)
     else:
-        raise ValueError(f"Argument '--model' should be one of "
-                         f"['base', 'mask', 'simple', 'window', 'full']. "
-                         f"Instead got '{model_name}'")
+        raise ValueError(f"Argument '--model' should be one of ['base', 'mask'"
+                         f", 'simple', 'patch', 'window', 'full']. "
+                         f"Instead got '{args.model}'")
 
     # Test
     createModelParams(model, model_file, device)

--- a/network/training.py
+++ b/network/training.py
@@ -250,7 +250,7 @@ def get_args():
                              "'mask', 'simple', 'patch', 'window', 'full'].")
     parser.add_argument('-N', "--size", type=int, default=256,
                         help="Number of sinograms per sample.")
-    parser.add_argument('-s', "--shifts", type=int, default=5,
+    parser.add_argument('-s', "--shifts", type=int, default=1,
                         help="Number of shifts per sample.")
     parser.add_argument("--tvt", type=int, default=[3, 1, 1], nargs=3,
                         help="Train/Validate/Test split, entered as a ratio.")

--- a/network/training.py
+++ b/network/training.py
@@ -10,8 +10,10 @@ import torchvision.transforms as transforms
 from .models import BaseGAN, WindowGAN, MaskedGAN, init_weights
 from .models.discriminators import *
 from .models.generators import *
-from .visualizers import BaseGANVisualizer, PairedWindowGANVisualizer, MaskedVisualizer
-from .datasets import PairedWindowDataset, BaseDataset, PairedFullDataset, MaskedDataset, RandomSubset
+from .visualizers import BaseGANVisualizer, PairedWindowGANVisualizer, \
+    MaskedVisualizer
+from .datasets import PairedWindowDataset, BaseDataset, PairedFullDataset, \
+    MaskedDataset, RandomSubset
 from utils.misc import Rescale
 
 
@@ -254,8 +256,8 @@ def get_args():
     parser.add_argument('-r', "--root", type=str, default='./data',
                         help="Path to input data used in network.")
     parser.add_argument('-m', "--model", type=str, default='base',
-                        help="Type of model to train. Must be one of "
-                             "['base', 'mask', 'simple', 'window', 'full'].")
+                        help="Type of model to train. Must be one of ['base', "
+                             "'mask', 'simple', 'patch', 'window', 'full'].")
     parser.add_argument('-N', "--size", type=int, default=256,
                         help="Number of sinograms per sample.")
     parser.add_argument('-s', "--shifts", type=int, default=5,
@@ -371,9 +373,18 @@ if __name__ == '__main__':
         model = MaskedGAN(gen, disc, mode='train', learning_rate=learning_rate,
                           betas=betas, lambdaL1=lambdal1, lsgan=lsgan,
                           device=device)
+    elif args.model == 'patch':
+        dataset = MaskedDataset(root=dataroot, mode='train', tvt=tvt,
+                                size=size, shifts=num_shifts,
+                                transform=transform, simple=True)
+        disc = PatchDiscriminator()
+        gen = PatchUNet()
+        model = MaskedGAN(gen, disc, mode='train', learning_rate=learning_rate,
+                          betas=betas, lambdaL1=lambdal1, lsgan=lsgan,
+                          device=device)
     else:
-        raise ValueError(f"Argument '--model' should be one of "
-                         f"['base', 'mask', 'simple', 'window', 'full']. "
+        raise ValueError(f"Argument '--model' should be one of ['base', 'mask'"
+                         f", 'simple', 'patch', 'window', 'full']. "
                          f"Instead got '{args.model}'")
 
     # Train

--- a/network/visualizers.py
+++ b/network/visualizers.py
@@ -98,7 +98,7 @@ class BaseGANVisualizer:
         if not self.block:
             classname = self.model.__class__.__name__
             num_losses = len(self.model.lossD_values)
-            savename = f"../images/{classname}_{num_losses}_losses.png"
+            savename = f"./images/{classname}_{num_losses}_losses.png"
             plt.savefig(savename)
         plt.show(block=self.block)
 

--- a/run_scripts/data_generator.sh
+++ b/run_scripts/data_generator.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Parameters (for full description of each parameter, see ../simulator/README.md)
-mode=complex # type of data to generate
+mode=patch # type of data to generate
 root='./data' # directory to save data in
 samples=1 # number of samples generate
 start=0 # sample number to begin counting at
-shifts=5 # number of vertical shifts for each sample
+shifts=1 # number of vertical shifts for each sample
 shift_step=5 # step in pixels between each shift
 size=256 # cubic size of sample generated
 objects=300 # number of objects to generate per sample
@@ -12,8 +12,13 @@ flatsnum=20 # the number of flat fields to generate
 I0=40000 # full-beam photon flux intensity
 pipeline='./tomo_pipeline.yml' # HTTomo YAML pipeline file
 hdf='/path/to/hdf_file.nxs' # Nexus file containing HDF data
+chunk=243 # no. of slices to load per chunk
+flat='/path/to/flat_file.nxs' # Nexus file containg flats & darks
+mask='/path/to/mask_file.npz' # Npz file containg mask of stripe locations
 angles=900 # number of angles per 'frame' of a dynamic scan
+patch_h=1801 # height of patches to split data into
+patch_w=256 # width of patches to split data into
 
 echo "Data generation has begun"
-python -m simulator.data_generator -m $mode -r $root -S $samples --start $start -s $shifts -p $shift_step -N $size -o $objects -f $flatsnum -I $I0 --pipeline $pipeline --hdf-file $hdf  --frame-angles $angles -v
+python -m simulator.data_generator -m $mode -r $root -S $samples --start $start -s $shifts -p $shift_step -N $size -o $objects -f $flatsnum -I $I0 --pipeline $pipeline --hdf-file $hdf -C $chunk --flats $flat --mask $mask --frame-angles $angles --patch-size $patch_h $patch_w -v
 echo "Data generation finished"

--- a/run_scripts/train_test.sh
+++ b/run_scripts/train_test.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 # Parameters (for full description of each parameter, see ../network/README.md)
 root="./data" # directory where input data is stored
-model="mask" # type of model to train. must be one of 'base', 'mask', 'simple', 'window' or 'full'
+model="patch" # type of model to train. must be one of 'base', 'mask', 'simple', 'patch', 'window' or 'full'
 size=256 # number of sinograms per sample
-shifts=5 # number of shifts in vertical height per sample
+shifts=1 # number of shifts in vertical height per sample
 batchsize=16 # batch size to load data in
 epochs=1 # number of epochs
 lr=0.0002 # learning rate
 beta1=0.5 # beta 1 for adam optimizer
 beta2=0.999 # beta 2 for adam optimizer
 lambda=100 # weight for L1 loss in generator
-savedir="./images" # directory in which to save the models during training
+savedir="./pretrained_models" # directory in which to save the models during training
 width=25 # width of windows
 # Other parameters, such as --lsgan, --subset, --metrics, etc. must be added to the commands below
 

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -295,3 +295,42 @@ The following parameters affect Dynamic mode:<br>
   - `--frame-angles`
     - The number of angles that make up a sinogram, i.e. one 'frame' of a dynamic scan.
     - Default is `900`.
+
+### Patch
+This method is the same as Paired, but split sinograms into patches of a given size.<br>
+Therefore, no downsampling is applied to sinograms.<br>
+
+This method stores data in the following directory structure:<br>
+```
+root
+├── fake_artifacts
+│   ├── clean
+│   │   ├── 0000_shift00_0000_w00.tif
+│   │   ├── 0000_shift00_0000_w01.tif
+│   │   ├── 0000_shift00_0000_w02.tif
+│   │   │   ...
+│   │   ├── 0000_shift00_0001_w00.tif
+│   │   │   ...
+│   │   ├── 0000_shift01_0000_w00.tif
+│   │   │   ...
+│   │   ...
+│   └── stripe
+└── real_artifacts
+    ├── clean
+    └── stripe
+```
+It is the same as Paired mode, but for each sinogram there is a series of patches `w00`, `w01`, `w02`, ...<br>
+
+The following parameters affect Patch mode:<br>
+  - `--shifts`, `-s`
+    - The number of vertical shifts when sample was scanned. Default is `5`.
+    - All shifts are stored under the same directory.
+    - Assumes shifts are each stored under a different .nxs file, with the name incrementing by one for each shift.
+    - For example, if shift 0 was in `1000.nxs`, shift 1 will be in `1001.nxs`, shift 2 in `1002.nxs`, etc.
+  - `--mask`
+    - The path to the mask containing locations of stripes. Default is `None`.
+    - This should be a numpy file `.npy`, generated using the stripe detection method in Larix.
+    - If not given, a mask will be generated at runtime. However, this can take multiple hours.
+  - `--patch-size`
+    - The size of patches to split sinograms into. Must be a tuple. Default is `(1801, 256)`.
+    - If the sinogram does not evenly go into patches of size `patch-size`, the sinogram will be cropped.

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -14,11 +14,12 @@ There are several sub-methods within these two:
    - Raw (*saves the data as-is, with no post-processing/pair-finding*)
    - Paired (*creates input/target pairs based on artifacts in sinograms*)
    - Dynamic (*for dynamic tomography scans*)
+   - Patch (*splits sinograms into smaller patches*)
 
 The following parameters affect *all* methods of generating data:
  - `--mode`, `-m`
    - The method to use when generating data. Default is `complex`.
-   - Must be one of `simple`, `complex`, `raw`, `paired`, or `dynamic`.
+   - Must be one of `simple`, `complex`, `raw`, `paired`, `dynamic`, or `patch`.
    - If it is not recognised, an error will be raised.
  - `--root`, `-r`
    - The main directory under which to store generated data. Default is `./data`.

--- a/simulator/data_generator.py
+++ b/simulator/data_generator.py
@@ -118,11 +118,11 @@ def get_args():
     parser.add_argument("--start", type=int, default=0,
                         help="Sample number to begin counting at (useful if "
                              "some data has already been generated).")
-    parser.add_argument('-s', "--shifts", type=int, default=5,
+    parser.add_argument('-s', "--shifts", type=int, default=1,
                         help="Number of vertical shifts for each sample. "
                              "Only affects modes 'complex', 'raw', 'paired', "
                              "and 'patch'.")
-    parser.add_argument('-p', "--shiftstep", type=int, default=2,
+    parser.add_argument('-p', "--shiftstep", type=int, default=5,
                         help="Shift step of a sample in pixels. "
                            "Only affects modes 'complex', 'raw' and 'paired'.")
     parser.add_argument('-N', "--size", type=int, default=256,

--- a/simulator/data_generator.py
+++ b/simulator/data_generator.py
@@ -84,7 +84,7 @@ def makeDirectories(dataDir, sampleNo, shifts, mode):
         os.makedirs(cleanPath, exist_ok=True)
         stripePath = os.path.join(mainPath, 'stripe')
         os.makedirs(stripePath, exist_ok=True)
-    elif mode == 'paired':
+    elif mode in ['paired', 'patch']:
         mainPath = os.path.join(dataDir, f'{sampleNo:04}')
         cleanRealArtPath = os.path.join(mainPath, 'real_artifacts', 'clean')
         stripeRealArtPath = os.path.join(mainPath, 'real_artifacts', 'stripe')
@@ -109,7 +109,8 @@ def get_args():
                                                  "generate samples of data.")
     parser.add_argument('-m', '--mode', type=str, default='complex',
                         help="Type of data to generate. Must be one of: "
-                           "['simple', 'complex', 'raw', 'paired', 'dynamic']")
+                             "['simple', 'complex', 'raw', 'paired', 'dynamic'"
+                             ", 'patch']")
     parser.add_argument('-r', '--root', type=str, default=None,
                         help="Directory to save data in.")
     parser.add_argument('-S', "--samples", type=int, default=1,
@@ -119,7 +120,8 @@ def get_args():
                              "some data has already been generated).")
     parser.add_argument('-s', "--shifts", type=int, default=5,
                         help="Number of vertical shifts for each sample. "
-                           "Only affects modes 'complex', 'raw' and 'paired'.")
+                             "Only affects modes 'complex', 'raw', 'paired', "
+                             "and 'patch'.")
     parser.add_argument('-p', "--shiftstep", type=int, default=2,
                         help="Shift step of a sample in pixels. "
                            "Only affects modes 'complex', 'raw' and 'paired'.")
@@ -137,23 +139,26 @@ def get_args():
                              "Only affects 'complex' mode.")
     parser.add_argument("--pipeline", type=str, default='tomo_pipeline.yml',
                         help="HTTomo YAML pipeline file for loading HDF data. "
-                           "Only affects modes 'raw', 'paired' and 'dynamic'.")
+                             "Only affects Real-life data modes.")
     parser.add_argument("--hdf-file", type=str, default=None,
                         help="Nexus file to load HDF data from. "
-                           "Only affects modes 'raw', 'paired' and 'dynamic'.")
+                             "Only affects Real-life data modes.")
     parser.add_argument('-C', "--chunk-size", type=int, default=243,
                         help="Size of chunks to load real-life data in. "
-                           "Only affects modes 'raw', 'paired' and 'dynamic'.")
+                             "Only affects Real-life data modes.")
     parser.add_argument("--flats", type=str, default=None,
                         help="Path to HDF file containing flat & dark fields. "
-                           "Only affects modes 'raw', 'paired' and 'dynamic'.")
+                             "Only affects Real-life data modes.")
     parser.add_argument("--mask", type=str, default=None,
                         help="Path to mask on stripe locations in data. "
                              "If left blank, a mask will be generated. Only "
-                             "affects 'paired' mode.")
+                             "affects modes 'paired' and 'patch'.")
     parser.add_argument("--frame-angles", type=int, default=900,
                         help="Number of angles per 'frame' of a scan. "
                              "Only affects 'dynamic' mode.")
+    parser.add_argument("--patch-size", type=int, default=[1801, 256], nargs=2,
+                        help="Size of patches to split data into. Only "
+                             "affects 'patch' mode.")
     parser.add_argument('-v', "--verbose", action="store_true",
                         help="Print some extra information when running")
     return parser.parse_args()
@@ -218,13 +223,14 @@ if __name__ == '__main__':
                                           output_path=mainPath,
                                           sampleNo=sampleNo,
                                           verbose=verbose)
-        elif args.mode in ['raw', 'paired', 'dynamic']:
+        elif args.mode in ['raw', 'paired', 'dynamic', 'patch']:
             if args.hdf_file is None:
                 raise ValueError(
                     "HDF File is None. Please include '--hdf-file' option.")
             mask = args.mask
             if mask is not None:
                 mask = np.load(mask)
+            patch_size = args.patch_size
             generate_real_data(mainPath,
                                args.hdf_file,
                                args.mode,
@@ -233,8 +239,9 @@ if __name__ == '__main__':
                                shifts,
                                args.flats,
                                mask=mask,
-                               frame_angles=angles_per_frame)
+                               frame_angles=angles_per_frame,
+                               patch_size=patch_size)
         else:
             raise ValueError(f"Option '--mode' should be one of 'simple', "
-                             f"'complex', 'raw', 'paired', 'dynamic'. "
-                             f"Instead got '{args.mode}'.")
+                             f"'complex', 'raw', 'paired', 'dynamic', 'patch'."
+                             f" Instead got '{args.mode}'.")

--- a/simulator/realdata_loader.py
+++ b/simulator/realdata_loader.py
@@ -159,6 +159,8 @@ def get_patch_paired_data(tomogram, mask=None, patch_size=(1801, 256)):
     """
     out = []
     for s in range(tomogram.shape[0]):
+        if s % 100 == 0:
+            print(f"Processing sinogram {s}/{tomogram.shape[0]}...", end=' ')
         sino_patches = create_patches(tomogram[s], patch_size)
         mask_patches = create_patches(mask[s], patch_size)
         tmp_out = np.ndarray(len(sino_patches),
@@ -172,7 +174,7 @@ def get_patch_paired_data(tomogram, mask=None, patch_size=(1801, 256)):
                 clean = sino_patches[p]
                 # Add synthetic stripes to clean sinogram patch
                 # currently done with TomoPhantom, other methods could be used
-                stripe = add_stripes(clean, percentage=0.4, maxthickness=2,
+                stripe = add_stripes(clean, percentage=0.4, maxthickness=6,
                                      intensity_thresh=0.2, stripe_type='full',
                                      variability=0)
                 # Clip back to original range
@@ -185,6 +187,8 @@ def get_patch_paired_data(tomogram, mask=None, patch_size=(1801, 256)):
                 real_artifact = True
             tmp_out[p] = real_artifact, stripe, clean
         out.append(tmp_out)
+        if s % 100 == 0:
+            print("Done.")
     return np.asarray(out)
 
 
@@ -336,6 +340,8 @@ def save_chunk(chunk, root, mode, start=0, sample_no=0, shift_no=0):
     elif mode == 'patch':
         basename = f'{sample_no:04}_shift{shift_no:02}'
         for s in range(chunk.shape[0]):
+            if s % 100 == 0:
+                print(f"Saving sinogram {s}/{chunk.shape[0]}...", end=' ')
             # Rescale each patch w.r.t sinogram, rather than chunk
             sino_min = np.nanmin(chunk[s]['stripe'])
             sino_max = np.nanmax(chunk[s]['stripe'])
@@ -356,6 +362,8 @@ def save_chunk(chunk, root, mode, start=0, sample_no=0, shift_no=0):
                     minmax[clean_path] = save_rescaled_sino(clean, sino_min,
                                                             sino_max,
                                                             clean_path)
+            if s % 100 == 0:
+                print("Done.")
     return minmax
 
 

--- a/simulator/realdata_loader.py
+++ b/simulator/realdata_loader.py
@@ -214,7 +214,7 @@ def get_data(mode, data, chunk_size, chunk_num, hdf_idx, **kwargs):
     """
     if mode == 'raw':
         return get_raw_data(data)
-    elif mode in ['real', 'patch']:
+    elif mode in ['paired', 'patch']:
         if 'mask' not in kwargs:
             raise ValueError("A mask should be given.")
         # Get correct mask for current shift
@@ -222,7 +222,7 @@ def get_data(mode, data, chunk_size, chunk_num, hdf_idx, **kwargs):
         # Crop mask to correct size
         mask_idx = np.s_[:, chunk_num * chunk_size:(chunk_num+1) * chunk_size]
         mask = np.swapaxes(mask[mask_idx], 0, 1)
-        if mode == 'real':
+        if mode == 'paired':
             return get_paired_data(data, mask=mask)
         if 'patch_size' not in kwargs:
             raise ValueError("Patch size should be given.")

--- a/simulator/realdata_loader.py
+++ b/simulator/realdata_loader.py
@@ -65,8 +65,8 @@ def get_paired_data(tomogram, mask=None):
     # Resize
     tomogram = resize_chunk(tomogram, (tomogram.shape[0], 402, 362))
     out = np.ndarray(tomogram.shape[0], dtype=[('real_artifact', '?'),
-                                               ('stripe', '<f8', (402, 362)),
-                                               ('clean', '<f8', (402, 362))])
+                                               ('stripe', 'f', (402, 362)),
+                                               ('clean', 'f', (402, 362))])
     # Generate mask if not given
     if mask is None:
         print("Mask not given so generating one...")


### PR DESCRIPTION
Adds the ability to generate "patches" of sinograms, rather than whole sinograms.
Patches are of size (1801, 256) by default, and are not downsampled.
The motivation behind this is two-fold:
1. The network only sees a smaller area around each stripe, allowing it to focus on important local information
2. By splitting one sinogram into many patches, the network has more data to train on

## Changes
- Added a new mode of generating data: "patch"
- Added a new mode for training & testing: "patch"
- Added a new visualizer class to display patch-based data
- Added wandb support
- Updated Dataset classes so that they can process synthetic, real-life and patch-based directory structures
- Datasets are now shuffled *before* the train/validate/test split, as well as after
- Increased width of simulated stripes, and removed the expansion of mask widths
- Minor bug fixes